### PR TITLE
as - add placeholder for GESearchPage

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -24,6 +24,8 @@ import CourseOverTimeInstructorIndexPage from "main/pages/CourseOverTime/CourseO
 
 import CourseOverTimeBuildingsIndexPage from "main/pages/CourseOverTime/CourseOverTimeBuildingsIndexPage";
 
+import GeneralEducationSearchPage from "main/pages/GeneralEducation/GeneralEducationSearchPage";
+
 import CourseDetailsIndexPage from "main/pages/CourseDetails/CourseDetailsIndexPage";
 function App() {
   const { data: currentUser } = useCurrentUser();
@@ -90,6 +92,11 @@ function App() {
           exact
           path="/courseovertime/instructorsearch"
           element={<CourseOverTimeInstructorIndexPage />}
+        />
+        <Route
+          exact
+          path="/generaleducation/search"
+          element={<GeneralEducationSearchPage />}
         />
         <Route
           exact

--- a/frontend/src/main/components/Nav/AppNavbar.js
+++ b/frontend/src/main/components/Nav/AppNavbar.js
@@ -14,8 +14,8 @@ export default function AppNavbar({
     <>
       {(currentUrl.startsWith("http://localhost:3000") ||
         currentUrl.startsWith("http://127.0.0.1:3000")) && (
-          <AppNavbarLocalhost url={currentUrl} />
-        )}
+        <AppNavbarLocalhost url={currentUrl} />
+      )}
       <Navbar
         expand="xl"
         variant="dark"

--- a/frontend/src/main/components/Nav/AppNavbar.js
+++ b/frontend/src/main/components/Nav/AppNavbar.js
@@ -14,8 +14,8 @@ export default function AppNavbar({
     <>
       {(currentUrl.startsWith("http://localhost:3000") ||
         currentUrl.startsWith("http://127.0.0.1:3000")) && (
-        <AppNavbarLocalhost url={currentUrl} />
-      )}
+          <AppNavbarLocalhost url={currentUrl} />
+        )}
       <Navbar
         expand="xl"
         variant="dark"
@@ -91,6 +91,12 @@ export default function AppNavbar({
                   data-testid="appnavbar-course-over-time-buildings-search"
                 >
                   Course Location History
+                </NavDropdown.Item>
+                <NavDropdown.Item
+                  href="/generaleducation/search"
+                  data-testid="appnavbar-general-education-area-search"
+                >
+                  Search by GE Area
                 </NavDropdown.Item>
                 <NavDropdown.Item
                   href="/courseovertime/instructorsearch"

--- a/frontend/src/main/pages/GeneralEducation/GeneralEducationSearchPage.js
+++ b/frontend/src/main/pages/GeneralEducation/GeneralEducationSearchPage.js
@@ -1,12 +1,12 @@
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
 
 export default function GeneralEducationSearchPage() {
-    // Stryker disable all : placeholder for future implementation
-    return (
-        <BasicLayout>
-            <div className="pt-2">
-                <h1>Search page not yet implemented</h1>
-            </div>
-        </BasicLayout>
-    );
+  // Stryker disable all : placeholder for future implementation
+  return (
+    <BasicLayout>
+      <div className="pt-2">
+        <h1>Search page not yet implemented</h1>
+      </div>
+    </BasicLayout>
+  );
 }

--- a/frontend/src/main/pages/GeneralEducation/GeneralEducationSearchPage.js
+++ b/frontend/src/main/pages/GeneralEducation/GeneralEducationSearchPage.js
@@ -1,0 +1,12 @@
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+
+export default function GeneralEducationSearchPage() {
+    // Stryker disable all : placeholder for future implementation
+    return (
+        <BasicLayout>
+            <div className="pt-2">
+                <h1>Search page not yet implemented</h1>
+            </div>
+        </BasicLayout>
+    );
+}

--- a/frontend/src/main/pages/GeneralEducation/GeneralEducationSearchPage.js
+++ b/frontend/src/main/pages/GeneralEducation/GeneralEducationSearchPage.js
@@ -5,7 +5,7 @@ export default function GeneralEducationSearchPage() {
   return (
     <BasicLayout>
       <div className="pt-2">
-        <h1>Search page not yet implemented</h1>
+        <h1>GE Search coming soon!</h1>
       </div>
     </BasicLayout>
   );

--- a/frontend/src/tests/pages/GeneralEducation/GeneralEducationSearchPage.test.js
+++ b/frontend/src/tests/pages/GeneralEducation/GeneralEducationSearchPage.test.js
@@ -38,11 +38,9 @@ describe("GeneralEducationSearchPage tests", () => {
       </QueryClientProvider>,
     );
 
-    await screen.findByText("Search page not yet implemented");
+    await screen.findByText("GE Search coming soon!");
 
     // assert
-    expect(
-      screen.getByText("Search page not yet implemented"),
-    ).toBeInTheDocument();
+    expect(screen.getByText("GE Search coming soon!")).toBeInTheDocument();
   });
 });

--- a/frontend/src/tests/pages/GeneralEducation/GeneralEducationSearchPage.test.js
+++ b/frontend/src/tests/pages/GeneralEducation/GeneralEducationSearchPage.test.js
@@ -1,0 +1,48 @@
+import { render, screen } from "@testing-library/react";
+import GeneralEducationSearchPage from "main/pages/GeneralEducation/GeneralEducationSearchPage";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+
+describe("GeneralEducationSearchPage tests", () => {
+  const axiosMock = new AxiosMockAdapter(axios);
+
+  const setupUserOnly = () => {
+    axiosMock.reset();
+    axiosMock.resetHistory();
+    axiosMock
+      .onGet("/api/currentUser")
+      .reply(200, apiCurrentUserFixtures.userOnly);
+    axiosMock
+      .onGet("/api/systemInfo")
+      .reply(200, systemInfoFixtures.showingNeither);
+  };
+
+  const queryClient = new QueryClient();
+  test("Renders expected content", async () => {
+    // arrange
+
+    setupUserOnly();
+
+    // act
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <GeneralEducationSearchPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await screen.findByText("Search page not yet implemented");
+
+    // assert
+    expect(
+      screen.getByText("Search page not yet implemented"),
+    ).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Closes #8,

In this PR, we add a placeholder page for the GESearchPage

Does not depend on any other PR to be merged first

Dokku: https://courses-alecsekimoto1.dokku-01.cs.ucsb.edu/generaleducation/search

<img width="322" alt="Screenshot 2025-05-19 at 10 52 55 AM" src="https://github.com/user-attachments/assets/1ebd40f1-1e60-472d-87e6-cf04d5e291d5" />

<img width="678" alt="Screenshot 2025-05-19 at 10 57 39 AM" src="https://github.com/user-attachments/assets/594d3f90-d165-40f6-9f47-7455b3793e54" />
