### PR TITLE
Creates API endpoint to get classrooms for a building

### DIFF
--- a/src/main/java/edu/ucsb/cs156/courses/controllers/CourseOverTimeBuildingController.java
+++ b/src/main/java/edu/ucsb/cs156/courses/controllers/CourseOverTimeBuildingController.java
@@ -8,7 +8,6 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import java.util.List;
 import java.util.stream.Collectors;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -57,52 +56,49 @@ public class CourseOverTimeBuildingController {
     String body = mapper.writeValueAsString(courseResults);
     return ResponseEntity.ok().body(body);
   }
-  
 
-  @Operation(
-    summary = "Get a list of classroom numbers for a building within a quarter range"
-  )
+  @Operation(summary = "Get a list of classroom numbers for a building within a quarter range")
   @GetMapping(value = "/classrooms", produces = "application/json")
   public ResponseEntity<String> getClassrooms(
       @Parameter(
-          name = "startQtr",
-          description =
-              "Starting quarter in yyyyq format, e.g. 20231 for W23, 20232 for S23, etc. (1=Winter, 2=Spring, 3=Summer, 4=Fall)",
-          example = "20231",
-          required = true)
-      @RequestParam
-      String startQtr,
+              name = "startQtr",
+              description =
+                  "Starting quarter in yyyyq format, e.g. 20231 for W23, 20232 for S23, etc. (1=Winter, 2=Spring, 3=Summer, 4=Fall)",
+              example = "20231",
+              required = true)
+          @RequestParam
+          String startQtr,
       @Parameter(
-          name = "endQtr",
-          description =
-              "Ending quarter in yyyyq format, e.g. 20231 for W23, 20232 for S23, etc. (1=Winter, 2=Spring, 3=Summer, 4=Fall)",
-          example = "20231",
-          required = true)
-      @RequestParam
-      String endQtr,
+              name = "endQtr",
+              description =
+                  "Ending quarter in yyyyq format, e.g. 20231 for W23, 20232 for S23, etc. (1=Winter, 2=Spring, 3=Summer, 4=Fall)",
+              example = "20231",
+              required = true)
+          @RequestParam
+          String endQtr,
       @Parameter(
-          name = "buildingCode",
-          description = "Building code such as PHELP for Phelps, GIRV for Girvetz",
-          example = "GIRV",
-          required = true)
-      @RequestParam
-      String buildingCode)
+              name = "buildingCode",
+              description = "Building code such as PHELP for Phelps, GIRV for Girvetz",
+              example = "GIRV",
+              required = true)
+          @RequestParam
+          String buildingCode)
       throws JsonProcessingException {
 
     List<ConvertedSection> sections =
         convertedSectionCollection.findByQuarterRangeAndBuildingCode(
             startQtr, endQtr, buildingCode);
 
-    List<String> rooms = sections.stream()
-        .flatMap(cs -> cs.getSection().getTimeLocations().stream())
-        .filter(tl -> buildingCode.equals(tl.getBuilding()))
-        .map(tl -> tl.getRoom())
-        .distinct()
-        .sorted()
-        .collect(Collectors.toList());
+    List<String> rooms =
+        sections.stream()
+            .flatMap(cs -> cs.getSection().getTimeLocations().stream())
+            .filter(tl -> buildingCode.equals(tl.getBuilding()))
+            .map(tl -> tl.getRoom())
+            .distinct()
+            .sorted()
+            .collect(Collectors.toList());
 
     String body = mapper.writeValueAsString(rooms);
     return ResponseEntity.ok().body(body);
   }
-
 }

--- a/src/main/java/edu/ucsb/cs156/courses/controllers/CourseOverTimeBuildingController.java
+++ b/src/main/java/edu/ucsb/cs156/courses/controllers/CourseOverTimeBuildingController.java
@@ -7,6 +7,8 @@ import edu.ucsb.cs156.courses.documents.ConvertedSection;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import java.util.List;
+import java.util.stream.Collectors;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -55,4 +57,52 @@ public class CourseOverTimeBuildingController {
     String body = mapper.writeValueAsString(courseResults);
     return ResponseEntity.ok().body(body);
   }
+  
+
+  @Operation(
+    summary = "Get a list of classroom numbers for a building within a quarter range"
+  )
+  @GetMapping(value = "/classrooms", produces = "application/json")
+  public ResponseEntity<String> getClassrooms(
+      @Parameter(
+          name = "startQtr",
+          description =
+              "Starting quarter in yyyyq format, e.g. 20231 for W23, 20232 for S23, etc. (1=Winter, 2=Spring, 3=Summer, 4=Fall)",
+          example = "20231",
+          required = true)
+      @RequestParam
+      String startQtr,
+      @Parameter(
+          name = "endQtr",
+          description =
+              "Ending quarter in yyyyq format, e.g. 20231 for W23, 20232 for S23, etc. (1=Winter, 2=Spring, 3=Summer, 4=Fall)",
+          example = "20231",
+          required = true)
+      @RequestParam
+      String endQtr,
+      @Parameter(
+          name = "buildingCode",
+          description = "Building code such as PHELP for Phelps, GIRV for Girvetz",
+          example = "GIRV",
+          required = true)
+      @RequestParam
+      String buildingCode)
+      throws JsonProcessingException {
+
+    List<ConvertedSection> sections =
+        convertedSectionCollection.findByQuarterRangeAndBuildingCode(
+            startQtr, endQtr, buildingCode);
+
+    List<String> rooms = sections.stream()
+        .flatMap(cs -> cs.getSection().getTimeLocations().stream())
+        .filter(tl -> buildingCode.equals(tl.getBuilding()))
+        .map(tl -> tl.getRoom())
+        .distinct()
+        .sorted()
+        .collect(Collectors.toList());
+
+    String body = mapper.writeValueAsString(rooms);
+    return ResponseEntity.ok().body(body);
+  }
+
 }

--- a/src/test/java/edu/ucsb/cs156/courses/controllers/CourseOverTimeBuildingControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/controllers/CourseOverTimeBuildingControllerTests.java
@@ -133,7 +133,12 @@ public class CourseOverTimeBuildingControllerTests {
   public void test_classrooms_validRequest() throws Exception {
     // build one ConvertedSection with two TimeLocations in GIRV
     CourseInfo info =
-        CourseInfo.builder().quarter("20222").courseId("X").title("Y").description("Z").build();
+        CourseInfo.builder()
+            .quarter("20222")
+            .courseId("CMPSC   24 -1")
+            .title("OBJ ORIENTED DESIGN")
+            .description("Intro to object oriented design")
+            .build();
 
     TimeLocation tl1 = new TimeLocation();
     tl1.setBuilding("GIRV");
@@ -143,8 +148,12 @@ public class CourseOverTimeBuildingControllerTests {
     tl2.setBuilding("GIRV");
     tl2.setRoom("2110");
 
+    TimeLocation drop = new TimeLocation();
+    drop.setBuilding("ELSB"); // different building
+    drop.setRoom("2002");
+
     Section section = new Section();
-    section.setTimeLocations(Arrays.asList(tl1, tl2));
+    section.setTimeLocations(Arrays.asList(tl1, tl2, drop));
 
     ConvertedSection cs = ConvertedSection.builder().courseInfo(info).section(section).build();
 

--- a/src/test/java/edu/ucsb/cs156/courses/controllers/CourseOverTimeBuildingControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/controllers/CourseOverTimeBuildingControllerTests.java
@@ -14,7 +14,6 @@ import edu.ucsb.cs156.courses.documents.ConvertedSection;
 import edu.ucsb.cs156.courses.documents.CourseInfo;
 import edu.ucsb.cs156.courses.documents.Section;
 import edu.ucsb.cs156.courses.documents.TimeLocation;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -105,79 +104,71 @@ public class CourseOverTimeBuildingControllerTests {
   }
 
   @Test
-public void test_classrooms_emptyRequest() throws Exception {
-  // no sections → expect empty room list
-  List<ConvertedSection> emptySecs = new ArrayList<>();
-  String urlTemplate =
-      "/api/public/courseovertime/classrooms?startQtr=%s&endQtr=%s&buildingCode=%s";
-  String url = String.format(urlTemplate, "20221", "20222", "GIRV");
+  public void test_classrooms_emptyRequest() throws Exception {
+    // no sections → expect empty room list
+    List<ConvertedSection> emptySecs = new ArrayList<>();
+    String urlTemplate =
+        "/api/public/courseovertime/classrooms?startQtr=%s&endQtr=%s&buildingCode=%s";
+    String url = String.format(urlTemplate, "20221", "20222", "GIRV");
 
-  // mock
-  when(convertedSectionCollection.findByQuarterRangeAndBuildingCode(
-          any(String.class), any(String.class), any(String.class)))
-      .thenReturn(emptySecs);
+    // mock
+    when(convertedSectionCollection.findByQuarterRangeAndBuildingCode(
+            any(String.class), any(String.class), any(String.class)))
+        .thenReturn(emptySecs);
 
-  // act
-  MvcResult response =
-      mockMvc
-          .perform(get(url).contentType("application/json"))
-          .andExpect(status().isOk())
-          .andReturn();
+    // act
+    MvcResult response =
+        mockMvc
+            .perform(get(url).contentType("application/json"))
+            .andExpect(status().isOk())
+            .andReturn();
 
-  // assert
-  String responseString = response.getResponse().getContentAsString();
-  String expectedString = mapper.writeValueAsString(new ArrayList<String>());
-  assertEquals(expectedString, responseString);
+    // assert
+    String responseString = response.getResponse().getContentAsString();
+    String expectedString = mapper.writeValueAsString(new ArrayList<String>());
+    assertEquals(expectedString, responseString);
+  }
+
+  @Test
+  public void test_classrooms_validRequest() throws Exception {
+    // build one ConvertedSection with two TimeLocations in GIRV
+    CourseInfo info =
+        CourseInfo.builder().quarter("20222").courseId("X").title("Y").description("Z").build();
+
+    TimeLocation tl1 = new TimeLocation();
+    tl1.setBuilding("GIRV");
+    tl1.setRoom("1004");
+
+    TimeLocation tl2 = new TimeLocation();
+    tl2.setBuilding("GIRV");
+    tl2.setRoom("2110");
+
+    Section section = new Section();
+    section.setTimeLocations(Arrays.asList(tl1, tl2));
+
+    ConvertedSection cs = ConvertedSection.builder().courseInfo(info).section(section).build();
+
+    List<ConvertedSection> repoResult = Arrays.asList(cs);
+    String urlTemplate =
+        "/api/public/courseovertime/classrooms?startQtr=%s&endQtr=%s&buildingCode=%s";
+    String url = String.format(urlTemplate, "20221", "20222", "GIRV");
+
+    // mock
+    when(convertedSectionCollection.findByQuarterRangeAndBuildingCode(
+            any(String.class), any(String.class), eq("GIRV")))
+        .thenReturn(repoResult);
+
+    // act
+    MvcResult response =
+        mockMvc
+            .perform(get(url).contentType("application/json"))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    // assert
+    List<String> expectedRooms = Arrays.asList("1004", "2110");
+    String expectedString = mapper.writeValueAsString(expectedRooms);
+    String responseString = response.getResponse().getContentAsString();
+    assertEquals(expectedString, responseString);
+  }
 }
-
-@Test
-public void test_classrooms_validRequest() throws Exception {
-  // build one ConvertedSection with two TimeLocations in GIRV
-  CourseInfo info = CourseInfo.builder()
-      .quarter("20222")
-      .courseId("X")
-      .title("Y")
-      .description("Z")
-      .build();
-
-  TimeLocation tl1 = new TimeLocation();
-  tl1.setBuilding("GIRV");
-  tl1.setRoom("1004");
-
-  TimeLocation tl2 = new TimeLocation();
-  tl2.setBuilding("GIRV");
-  tl2.setRoom("2110");
-
-  Section section = new Section();
-  section.setTimeLocations(Arrays.asList(tl1, tl2));
-
-  ConvertedSection cs = ConvertedSection.builder()
-      .courseInfo(info)
-      .section(section)
-      .build();
-
-  List<ConvertedSection> repoResult = Arrays.asList(cs);
-  String urlTemplate =
-      "/api/public/courseovertime/classrooms?startQtr=%s&endQtr=%s&buildingCode=%s";
-  String url = String.format(urlTemplate, "20221", "20222", "GIRV");
-
-  // mock
-  when(convertedSectionCollection.findByQuarterRangeAndBuildingCode(
-          any(String.class), any(String.class), eq("GIRV")))
-      .thenReturn(repoResult);
-
-  // act
-  MvcResult response =
-      mockMvc
-          .perform(get(url).contentType("application/json"))
-          .andExpect(status().isOk())
-          .andReturn();
-
-  // assert
-  List<String> expectedRooms = Arrays.asList("1004", "2110");
-  String expectedString = mapper.writeValueAsString(expectedRooms);
-  String responseString = response.getResponse().getContentAsString();
-  assertEquals(expectedString, responseString);
-}
-}
-


### PR DESCRIPTION
closes #15 

In this PR we create an API endpoint to get classrooms for a building.

This does not depend on any other PR to be merged

To deploy:
Checkout Branch on local machine
Run 
`mvn spring-boot:run` on source folder 
and
`npm start` in frontend folder

Navigate to localhost:8080

Go to swagger and you should see the below api call
You can confirm values are correct by cross referencing with /buildingsearch api call

Dokku Deployment at 
https://courses-oscar-luna.dokku-01.cs.ucsb.edu

All classrooms used in a building
![Screenshot 2025-05-19 at 11 24 25 PM](https://github.com/user-attachments/assets/7fe5479c-6928-45c3-8b75-ccfc02812ebf)

One of the classrooms from that building
![Screenshot 2025-05-19 at 11 28 28 PM](https://github.com/user-attachments/assets/7bd5ac7d-5e95-45b0-9aee-1631ae05b7b1)
