### PR TITLE
Added the backend controller that returns search result for general education search

### DIFF
--- a/frontend/src/main/components/GeneralEducation/GeneralEducationSearchForm.js
+++ b/frontend/src/main/components/GeneralEducation/GeneralEducationSearchForm.js
@@ -43,8 +43,6 @@ const GeneralEducationSearchForm = ({ fetchJSON }) => {
     fetchJSON(event, { quarter, geArea });
   };
 
-  //   const testid = "GeneralEducationSearchForm";
-
   return (
     <Form onSubmit={handleSubmit}>
       <Container>

--- a/src/main/java/edu/ucsb/cs156/courses/collections/ConvertedSectionCollection.java
+++ b/src/main/java/edu/ucsb/cs156/courses/collections/ConvertedSectionCollection.java
@@ -27,6 +27,12 @@ public interface ConvertedSectionCollection extends MongoRepository<ConvertedSec
   List<ConvertedSection> findByQuarterRangeAndBuildingCode(
       String startQuarter, String endQuarter, String buildingCode);
 
+      @Query("{'courseInfo.quarter': { $gte: ?0, $lte: ?1 }, 'courseInfo.generalEducation': { $elemMatch: { 'geCode': { $regex: ?2 } } } }")
+      List<ConvertedSection> findByQuarterRangeAndGECode(
+          String startQuarter, String endQuarter, String geCode);
+
   @Query("{'courseInfo.quarter': { $eq: ?0 } }")
   List<ConvertedSection> findByQuarter(String quarter);
+
+  
 }

--- a/src/main/java/edu/ucsb/cs156/courses/collections/ConvertedSectionCollection.java
+++ b/src/main/java/edu/ucsb/cs156/courses/collections/ConvertedSectionCollection.java
@@ -27,12 +27,11 @@ public interface ConvertedSectionCollection extends MongoRepository<ConvertedSec
   List<ConvertedSection> findByQuarterRangeAndBuildingCode(
       String startQuarter, String endQuarter, String buildingCode);
 
-      @Query("{'courseInfo.quarter': { $gte: ?0, $lte: ?1 }, 'courseInfo.generalEducation': { $elemMatch: { 'geCode': { $regex: ?2 } } } }")
-      List<ConvertedSection> findByQuarterRangeAndGECode(
-          String startQuarter, String endQuarter, String geCode);
+  @Query(
+      "{'courseInfo.quarter': { $gte: ?0, $lte: ?1 }, 'courseInfo.generalEducation': { $elemMatch: { 'geCode': { $regex: ?2 } } } }")
+  List<ConvertedSection> findByQuarterRangeAndGECode(
+      String startQuarter, String endQuarter, String geCode);
 
   @Query("{'courseInfo.quarter': { $eq: ?0 } }")
   List<ConvertedSection> findByQuarter(String quarter);
-
-  
 }

--- a/src/main/java/edu/ucsb/cs156/courses/controllers/GeneralEducationFullController.java
+++ b/src/main/java/edu/ucsb/cs156/courses/controllers/GeneralEducationFullController.java
@@ -41,16 +41,12 @@ public class GeneralEducationFullController {
               required = true)
           @RequestParam
           String endQtr,
-      @Parameter(
-              name = "geCode",
-              description = "GE Code",
-              example = "A1",
-              required = true)
+      @Parameter(name = "geCode", description = "GE Code", example = "A1", required = true)
           @RequestParam
           String geCode)
       throws JsonProcessingException {
-    List<ConvertedSection> courseResults = 
-          convertedSectionCollection.findByQuarterRangeAndGECode(startQtr, endQtr, geCode);
+    List<ConvertedSection> courseResults =
+        convertedSectionCollection.findByQuarterRangeAndGECode(startQtr, endQtr, geCode);
     String body = mapper.writeValueAsString(courseResults);
     return ResponseEntity.ok().body(body);
   }

--- a/src/main/java/edu/ucsb/cs156/courses/controllers/GeneralEducationFullController.java
+++ b/src/main/java/edu/ucsb/cs156/courses/controllers/GeneralEducationFullController.java
@@ -1,0 +1,57 @@
+package edu.ucsb.cs156.courses.controllers;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import edu.ucsb.cs156.courses.collections.ConvertedSectionCollection;
+import edu.ucsb.cs156.courses.documents.ConvertedSection;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import java.util.List;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/public/generalEducation")
+public class GeneralEducationFullController {
+
+  private ObjectMapper mapper = new ObjectMapper();
+
+  @Autowired ConvertedSectionCollection convertedSectionCollection;
+
+  @Operation(summary = "Get a list of courses over time, filtered by GE Area")
+  @GetMapping(value = "/gesearch", produces = "application/json")
+  public ResponseEntity<String> search(
+      @Parameter(
+              name = "startQtr",
+              description =
+                  "Starting quarter in yyyyq format, e.g. 20231 for W23, 20232 for S23, etc. (1=Winter, 2=Spring, 3=Summer, 4=Fall)",
+              example = "20231",
+              required = true)
+          @RequestParam
+          String startQtr,
+      @Parameter(
+              name = "endQtr",
+              description =
+                  "Ending quarter in yyyyq format, e.g. 20231 for W23, 20232 for S23, etc. (1=Winter, 2=Spring, 3=Summer, 4=Fall)",
+              example = "20231",
+              required = true)
+          @RequestParam
+          String endQtr,
+      @Parameter(
+              name = "geCode",
+              description = "GE Code",
+              example = "A1",
+              required = true)
+          @RequestParam
+          String geCode)
+      throws JsonProcessingException {
+    List<ConvertedSection> courseResults = 
+          convertedSectionCollection.findByQuarterRangeAndGECode(startQtr, endQtr, geCode);
+    String body = mapper.writeValueAsString(courseResults);
+    return ResponseEntity.ok().body(body);
+  }
+}

--- a/src/test/java/edu/ucsb/cs156/courses/controllers/GeneralEducationFullControllerTest.java
+++ b/src/test/java/edu/ucsb/cs156/courses/controllers/GeneralEducationFullControllerTest.java
@@ -1,0 +1,102 @@
+package edu.ucsb.cs156.courses.controllers;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import edu.ucsb.cs156.courses.collections.ConvertedSectionCollection;
+import edu.ucsb.cs156.courses.config.SecurityConfig;
+import edu.ucsb.cs156.courses.documents.ConvertedSection;
+import edu.ucsb.cs156.courses.documents.CourseInfo;
+import edu.ucsb.cs156.courses.documents.Section;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+@WebMvcTest(value = GeneralEducationFullController.class)
+@Import(SecurityConfig.class)
+@AutoConfigureDataJpa
+public class GeneralEducationFullControllerTest {
+
+  private ObjectMapper mapper = new ObjectMapper();
+
+  @Autowired private MockMvc mockMvc;
+
+  @MockBean ConvertedSectionCollection convertedSectionCollection;
+
+  @Test
+  public void test_search_emptyResult() throws Exception {
+    List<ConvertedSection> expectedResult = new ArrayList<ConvertedSection>();
+    String urlTemplate = "/api/public/generalEducation/gesearch?startQtr=%s&endQtr=%s&geCode=%s";
+    String url = String.format(urlTemplate, "20221", "20222", "A1");
+
+    // Mock the repository call
+    when(convertedSectionCollection.findByQuarterRangeAndGECode(
+            any(String.class), any(String.class), any(String.class)))
+        .thenReturn(expectedResult);
+
+    // Perform the request
+    MvcResult response =
+        mockMvc
+            .perform(get(url).contentType("application/json"))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    // Assert the response
+    String responseString = response.getResponse().getContentAsString();
+    String expectedString = mapper.writeValueAsString(expectedResult);
+    assertEquals(expectedString, responseString);
+  }
+
+  @Test
+  public void test_search_validResult() throws Exception {
+    CourseInfo info =
+        CourseInfo.builder()
+            .quarter("20222")
+            .courseId("CMPSC   24 -1")
+            .title("OBJ ORIENTED DESIGN")
+            .description("Intro to object oriented design")
+            .build();
+
+    Section section1 = new Section();
+    Section section2 = new Section();
+
+    ConvertedSection cs1 = ConvertedSection.builder().courseInfo(info).section(section1).build();
+    ConvertedSection cs2 = ConvertedSection.builder().courseInfo(info).section(section2).build();
+
+    List<ConvertedSection> expectedResult = Arrays.asList(cs1, cs2);
+
+    String urlTemplate = "/api/public/generalEducation/gesearch?startQtr=%s&endQtr=%s&geCode=%s";
+    String url = String.format(urlTemplate, "20221", "20222", "A1");
+
+    // Mock the repository call
+    when(convertedSectionCollection.findByQuarterRangeAndGECode(
+            eq("20221"), eq("20222"), eq("A1")))
+        .thenReturn(expectedResult);
+
+    // Perform the request
+    MvcResult response =
+        mockMvc
+            .perform(get(url).contentType("application/json"))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    // Assert the response
+    String responseString = response.getResponse().getContentAsString();
+    String expectedString = mapper.writeValueAsString(expectedResult);
+    assertEquals(expectedString, responseString);
+  }
+
+}

--- a/src/test/java/edu/ucsb/cs156/courses/controllers/GeneralEducationFullControllerTest.java
+++ b/src/test/java/edu/ucsb/cs156/courses/controllers/GeneralEducationFullControllerTest.java
@@ -82,8 +82,7 @@ public class GeneralEducationFullControllerTest {
     String url = String.format(urlTemplate, "20221", "20222", "A1");
 
     // Mock the repository call
-    when(convertedSectionCollection.findByQuarterRangeAndGECode(
-            eq("20221"), eq("20222"), eq("A1")))
+    when(convertedSectionCollection.findByQuarterRangeAndGECode(eq("20221"), eq("20222"), eq("A1")))
         .thenReturn(expectedResult);
 
     // Perform the request
@@ -98,5 +97,4 @@ public class GeneralEducationFullControllerTest {
     String expectedString = mapper.writeValueAsString(expectedResult);
     assertEquals(expectedString, responseString);
   }
-
 }


### PR DESCRIPTION
In this PR, we added backend controller for the general area search function and the tests for it. 

Dokku deployment: https://courses-ran.dokku-01.cs.ucsb.edu/

Test Plan: 

Please go to https://courses-ran.dokku-01.cs.ucsb.edu/swagger-ui/index.html#/general-education-full-controller/search

<img width="1363" alt="Screenshot 2025-05-23 at 12 50 42 AM" src="https://github.com/user-attachments/assets/44cb58d5-bf62-46d8-9a7f-8b75353e55fa" />
<img width="1376" alt="Screenshot 2025-05-23 at 12 50 51 AM" src="https://github.com/user-attachments/assets/6d84722f-9dfa-414b-9e62-7c1da095d9eb" />
